### PR TITLE
feat - add geojson writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ osmpbfreader = "0.16.0"
 csv = "1.1.3"
 docopt = "1.1.0"
 serde = "1.0"
+serde_json = "1.0.97"
 
 [lib]
 name = "osm4routing"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,3 @@ pub use crate::osm4routing::categorize::{
 pub use crate::osm4routing::models::*;
 pub use crate::osm4routing::reader::{read, Reader};
 pub use crate::osm4routing::writers;
-pub use osmpbfreader::objects::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,24 @@
 fn main() {
     const USAGE: &str = "
-Usage: osm4routing <source.osm.pbf>";
+Usage: osm4routing <source.osm.pbf> [--format=<output_format>]
+Options:
+    --format=<output_format>  Output format (csv or geojson) [default: csv]";
+
     let args = docopt::Docopt::new(USAGE)
         .unwrap()
         .parse()
         .unwrap_or_else(|e| e.exit());
     let filename = args.get_str("<source.osm.pbf>");
+
     match osm4routing::read(filename) {
-        Ok((nodes, edges)) => osm4routing::writers::csv(nodes, edges),
+        Ok((nodes, edges)) => {
+            let fmt = args.get_str("--format");
+            match fmt {
+                "csv" | "" => osm4routing::writers::csv(nodes, edges),
+                "geojson" => osm4routing::writers::geojson(nodes, edges),
+                _ => println!("Invalid output format. Please choose csv or geojson."),
+            }
+        },
         Err(error) => println!("Error: {}", error),
     }
 }

--- a/src/osm4routing/models.rs
+++ b/src/osm4routing/models.rs
@@ -49,6 +49,14 @@ impl Edge {
         format!("LINESTRING({})", coords.as_slice().join(", "))
     }
 
+    // Coordinates in the GeoJSON format
+    pub fn coordinates(&self) -> Vec<Vec<f64>> {
+        self.geometry
+            .iter()
+            .map(|coord| vec![coord.lon, coord.lat])
+            .collect()
+    }
+
     // Length in meters of the edge
     pub fn length(&self) -> f64 {
         self.geometry


### PR DESCRIPTION
We can now choose between csv or geojson output 

```
Usage: osm4routing <source.osm.pbf> [--format=<output_format>]
Options:
    --format=<output_format>  Output format (csv or geojson) [default: csv]
 ```